### PR TITLE
Tweaking the way the warning is displayed

### DIFF
--- a/colcon_ros_cargo/package_identification/ament_cargo.py
+++ b/colcon_ros_cargo/package_identification/ament_cargo.py
@@ -47,10 +47,12 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
 
         ament_build = 'cargo ament-build --help'.split()
         if subprocess.run(ament_build, capture_output=True).returncode != 0:
-            logger.error(
-                'ament_cargo package found but cargo ament-build was not '
-                'detected. Please install it by running: '
-                '`cargo install cargo-ament-build`')
+            if print_ament_cargo_warning_once():
+                logger.error(
+                    '\n\nament_cargo package found but cargo ament-build was not '
+                    'detected.'
+                    '\n\nPlease install it by running:'
+                    '\n $ cargo install cargo-ament-build\n')
             return
 
         metadata.type = 'ament_cargo'
@@ -64,3 +66,19 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
             {dep.name for dep in pkg.run_depends}
         metadata.dependencies['test'] = \
             {dep.name for dep in pkg.test_depends}
+
+def print_ament_cargo_warning_once():
+    global has_printed_ament_cargo_warning
+    try:
+        # The following line will throw an exception if the global variable
+        # has never been initialized
+        has_printed_ament_cargo_warning
+    except NameError:
+        # We want to initialize the global variable to false the first time
+        has_printed_ament_cargo_warning = False
+
+    if not has_printed_ament_cargo_warning:
+        has_printed_ament_cargo_warning = True
+        return True
+
+    return False


### PR DESCRIPTION
Following the [upstream discussion](https://github.com/colcon/colcon-ros-cargo/pull/31#discussion_r1853186767) I started playing around with the way the warning gets displayed.

Here's where I settled after my own experimentation:
* Pad the warning with lots of newlines so the warning doesn't get lost in the noise of the header
* Push the `$` to the right with a space to make it stand out a little better
* Use a global variable so that the warning is only printed once, no matter how many ament-cargo packages are in the workspace

The resulting terminal output looks like this:
![Screenshot from 2024-11-22 18-01-32](https://github.com/user-attachments/assets/6b815a34-9b1f-403f-a1b7-3e3134ca6fe1)

I'd prefer if it could be highlighted in yellow or red, but I think this is visible enough that users won't easily overlook it.